### PR TITLE
Static pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
   allow_unauthenticated_access
-  def contact
+  def show
+    render params[:id]
   end
 end

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,0 +1,1 @@
+<h1>Page à propos</h1>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,9 +4,8 @@
     <ul class="navbar-links">
        <%= link_to "Accueil", root_path %>
        <%= link_to "Catalogue", items_path %>
-       # a propos
-       # contact
-      
+       <%= link_to "A propos", page_path("about")%> 
+       <%= link_to "Contact", page_path("contact")%>
     </ul>
 
     <div class="navbar-right">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,15 @@
 Rails.application.routes.draw do
 
 
-  get "pages/contact"    # IL FAUT QUE CA DEGAGE 
   
   resource :session, only: %i[new create destroy]
   resource :registration, only: %i[new create]
   resources :users
   resources :items
   resources :passwords, param: :token
+  resources :pages
 
 
-  get "/contact", to: "pages#contact", as: :contact
 
   
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class HomeControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get home_index_url
-    assert_response :success
-  end
-end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class PagesControllerTest < ActionDispatch::IntegrationTest
-  test "should get contact" do
-    get pages_contact_url
-    assert_response :success
-  end
-end

--- a/test/controllers/photos_controller_test.rb
+++ b/test/controllers/photos_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class PhotosControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get photos_index_url
-    assert_response :success
-  end
-end


### PR DESCRIPTION
Implemented the static pages controller, deleted the static routes, the controller only has one method "show" that takes the name of the static page you want to access as the argument, which is specified in the URL